### PR TITLE
Added RSA helper function

### DIFF
--- a/rsa/rsa_factory.go
+++ b/rsa/rsa_factory.go
@@ -12,67 +12,49 @@
 package rsa
 
 import (
-	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
-	"encoding/asn1"
 	"encoding/base64"
-	"encoding/pem"
-	"fmt"
 )
 
 // GenerateRSAKeyPair generates a RSA key pair for the provided bit size.
-// Recommended bit size is 4096
-func GenerateRSAKeyPair(bitSize int) (*pem.Block, *pem.Block, error) {
+func GenerateRSAKeyPair() (*rsa.PrivateKey, error) {
 	reader := rand.Reader
+	return rsa.GenerateKey(reader, 4096)
+}
 
-	key, err := rsa.GenerateKey(reader, bitSize)
+// EvalHash generates a SHA256 hash as string for the provided pem block
+func EvalHash(p *rsa.PublicKey) (string, error) {
+	b := x509.MarshalPKCS1PublicKey(p)
+	h := sha256.Sum256(b)
+	b64 := base64.StdEncoding.EncodeToString(h[:])
+	return b64, nil
+}
+
+// Encode converts a rsa.PublicKey to a base64 encoded pkcs1 string
+func Encode(p *rsa.PublicKey) (string, error) {
+	b := x509.MarshalPKCS1PublicKey(p)
+	s := base64.StdEncoding.EncodeToString(b)
+	return s, nil
+}
+
+// Decode converts a base64 encoded pkcs1 string to a *rsa.PublicKey
+func Decode(s string) (*rsa.PublicKey, error) {
+	der, err := base64.StdEncoding.DecodeString(s)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-
-	publicKey := key.PublicKey
-
-	asn1Bytes, err := asn1.Marshal(publicKey)
-	pemkeyPublic := &pem.Block{
-		Type:  "PUBLIC KEY",
-		Bytes: asn1Bytes,
-	}
-
-	var privateKey = &pem.Block{
-		Type:  "PRIVATE KEY",
-		Bytes: x509.MarshalPKCS1PrivateKey(key),
-	}
-
-	return pemkeyPublic, privateKey, nil
+	return x509.ParsePKCS1PublicKey(der)
 }
 
-// EvalHash generates a SHA256 hash key for the provided pem block
-func EvalHash(pem *pem.Block) [32]byte {
-	return sha256.Sum256(pem.Bytes)
+// Decrypt decrypts a message with the provided rsa.PrivateKey
+func Decrypt(p *rsa.PrivateKey, cipher []byte) ([]byte, error) {
+	return rsa.DecryptOAEP(sha256.New(), rand.Reader, p, cipher, nil)
 }
 
-// EvalHash generates a SHA256 hash key as string for the provided pem block
-func EvalHashToBase64(pem *pem.Block) string {
-	b := EvalHash(pem)
-	return base64.StdEncoding.EncodeToString(b[:])
-}
-
-// EncodePem converts a pem block to a slice of bytes, ready to be serialized
-// To deserialize back into a pem Block, use DecodePem
-func EncodePem(p *pem.Block) ([]byte, error) {
-	var buf bytes.Buffer
-	err := pem.Encode(&buf, p)
-	return buf.Bytes(), err
-}
-
-// DecodePem converts a slice of bytes to a pem block, useful for deserialization
-func DecodePem(key []byte) (*pem.Block, error) {
-	pem, _ := pem.Decode(key)
-	if pem == nil {
-		return nil, fmt.Errorf("failed to decode private key")
-	}
-	return pem, nil
+// Encrypt encrypts a message with the provided rsa.PublicKey
+func Encrypt(p *rsa.PublicKey, cipher []byte) ([]byte, error) {
+	return rsa.EncryptOAEP(sha256.New(), rand.Reader, p, cipher, nil)
 }

--- a/rsa/rsa_factory.go
+++ b/rsa/rsa_factory.go
@@ -18,6 +18,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/asn1"
+	"encoding/base64"
 	"encoding/pem"
 	"fmt"
 )
@@ -51,6 +52,12 @@ func GenerateRSAKeyPair(bitSize int) (*pem.Block, *pem.Block, error) {
 // EvalHash generates a SHA256 hash key for the provided pem block
 func EvalHash(pem *pem.Block) [32]byte {
 	return sha256.Sum256(pem.Bytes)
+}
+
+// EvalHash generates a SHA256 hash key as string for the provided pem block
+func EvalHashToBase64(pem *pem.Block) string {
+	b := EvalHash(pem)
+	return base64.StdEncoding.EncodeToString(b[:])
 }
 
 // EncodePem converts a pem block to a slice of bytes, ready to be serialized

--- a/rsa/rsa_factory_test.go
+++ b/rsa/rsa_factory_test.go
@@ -30,21 +30,20 @@ func TestRSAGeneration(t *testing.T) {
 
 func TestEvalHash(t *testing.T) {
 
-	pub, err := readKey("testdata/public.pem")
+	pub, err := readPublicKey("testdata/public.pem")
 	if err != nil {
 		t.Fatal("Failed to read public key", err)
 	}
 
 	hash, err := EvalHash(pub)
 
-	fmt.Println(hash)
 	if err != nil || hash != "BTx5GBFv1S8yMqehO5TvvgoKk5om7FcFIkSJlMtXGiw=" {
 		t.Fail()
 	}
 }
 
 func TestEncodeDecode(t *testing.T) {
-	s, err := readKey("testdata/public.pem")
+	s, err := readPublicKey("testdata/public.pem")
 	if err != nil {
 		t.Fatal("Failed to read public key", err)
 	}
@@ -82,7 +81,7 @@ func TestEcryptDecrypt(t *testing.T) {
 	}
 }
 
-func readKey(filename string) (*rsa.PublicKey, error) {
+func readPublicKey(filename string) (*rsa.PublicKey, error) {
 	f, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Exposing only the necessary functions which is best used from both sides:
* GenerateRSAKeyPair() (*rsa.PrivateKey)
* Return a base64-encoded hash (*rsa.PublicKey) (string, error)
* Return a base64-encoded public key (*rsa.PublicKey) (string, erorr)
* Parse base64-encoded public key (string) (*rsa.PublicKey, error)
* Decrypt(*rsa.PrivateKey, []byte) ([]byte, error)
* Encrypt(*rsa.PublicKey, []byte) ([]byte, error)

The end goal is not to end up chasing decryption errors or hashsum mismatches