### PR TITLE
allow checkvalue of different lengths

### DIFF
--- a/des/des_cipher.go
+++ b/des/des_cipher.go
@@ -19,6 +19,11 @@ import (
 	"strings"
 )
 
+const (
+	checkValueDefaultBytes = 3
+	checkValueMinimumBytes = 2
+)
+
 var keyCheckValuePlainText8Bytes = []byte{0, 0, 0, 0, 0, 0, 0, 0}
 
 // Cipher is wrapper of the DES or 3DES cipher and stores the raw key bytes
@@ -70,11 +75,16 @@ func (cipher *Cipher) DecryptHex(ciphertext string) ([]byte, error) {
 }
 
 func (cipher *Cipher) VerifyCheckValue(checkValue string) bool {
+	checkValueBytes := len(checkValue) / 2
+	if checkValueBytes < checkValueMinimumBytes || checkValueBytes > len(keyCheckValuePlainText8Bytes) {
+		return false
+	}
+
 	cipherBytes, err := cipher.Encrypt(keyCheckValuePlainText8Bytes)
 	if err != nil {
 		return false
 	}
-	derivedCheckValue := hex.EncodeToString(cipherBytes[:3])
+	derivedCheckValue := hex.EncodeToString(cipherBytes[:checkValueBytes])
 	return strings.EqualFold(derivedCheckValue, checkValue)
 }
 
@@ -83,5 +93,5 @@ func (cipher *Cipher) CheckValue() string {
 	if err != nil {
 		return ""
 	}
-	return hex.EncodeToString(cipherBytes[:3])
+	return hex.EncodeToString(cipherBytes[:checkValueDefaultBytes])
 }

--- a/des/des_cipher_test.go
+++ b/des/des_cipher_test.go
@@ -162,6 +162,14 @@ func TestTripleDESCheckValueVerification(t *testing.T) {
 	if cipher.VerifyCheckValue("6FAAD4") {
 		t.Error("expect checkValue to be invalid")
 	}
+
+	if cipher.VerifyCheckValue("6F") {
+		t.Error("expect checkValue to be invalid if it is below the minimum required length")
+	}
+
+	if cipher.VerifyCheckValue("F94AC55104B0E5532D0A61D2D2C6C655F94AC55104B0E553") {
+		t.Error("expect checkValue to be invalid if it is above the max allowed length")
+	}
 }
 
 func TestTripleDESCheckValue(t *testing.T) {

--- a/des/des_cipher_test.go
+++ b/des/des_cipher_test.go
@@ -159,6 +159,10 @@ func TestTripleDESCheckValueVerification(t *testing.T) {
 		t.Error("expect checkValue to be valid")
 	}
 
+	if !cipher.VerifyCheckValue("6FAA") {
+		t.Error("expect checkValue to be valid")
+	}
+
 	if cipher.VerifyCheckValue("6FAAD4") {
 		t.Error("expect checkValue to be invalid")
 	}


### PR DESCRIPTION
Update VerifyCheckValue to accept any checkvalue whose length is in the allowed range.

<!-- What changes have you made? Anything else we should keep in mind? -->

## Checklist
- [x] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
