### PR TITLE
Added description field to kek bundle

### DIFF
--- a/kek/kek_bundle.go
+++ b/kek/kek_bundle.go
@@ -31,6 +31,8 @@ type Bundle struct {
 	CheckValue string
 	// imported components index value map
 	Components map[int][]byte
+	// free text description of the key
+	Description string
 }
 
 func New(name string, index int, size int, checkValue string) *Bundle {
@@ -79,4 +81,12 @@ func (b *Bundle) Merge() (des.Cipher, error) {
 	}
 
 	return kekCipher, nil
+}
+
+// Protects the description from being erased. Since a bundle is constructed of
+// multiple requests, this method makes it mroe convenient
+func (b *Bundle) SetDescription(desc string) {
+	if len(b.Description) < len(desc) {
+		b.Description = desc
+	}
 }

--- a/kek/kek_bundle_test.go
+++ b/kek/kek_bundle_test.go
@@ -117,3 +117,13 @@ func TestMergeResultKeySuccess(t *testing.T) {
 		t.Fatalf("Expected %s but got back %s", expectedKey, hex.EncodeToString(resultKey.KeyBytes))
 	}
 }
+
+func TestOverwriteDescription(t *testing.T) {
+	kek := New("visa", 1, 3, "2D617C")
+	kek.SetDescription("desc")
+	kek.SetDescription("")
+
+	if kek.Description != "desc" {
+		t.Fatalf("Expected non empty description")
+	}
+}


### PR DESCRIPTION
## Context

We are starting to get more and more keys and we start losing track of what they are for. Adding free-text description would make things easier for operators.

### Changes

Added `Description` field to Bundle. Intended to be used by the vault plugins

## Checklist
- [ ] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
