### PR TITLE
chore: add tw-rules to control repo access and merge conditions

### DIFF
--- a/.github/tw-rules.yaml
+++ b/.github/tw-rules.yaml
@@ -2,11 +2,11 @@ runChecks: true
 actions:
   branch-protection-settings:
     branches:
-      - name: main
+      - name: master
         dismissStaleReviews: true
         requireBranchUpToDate: true
         checks:
           - name: Build & Test
             type: tests
   sync-code-owners:
-    extraWriters: ["plastic-issuance-service-owners"]
+    extraWriters: ["full-time-technical-staff", "plastic-issuance-service-owners"]

--- a/.github/tw-rules.yaml
+++ b/.github/tw-rules.yaml
@@ -1,0 +1,12 @@
+runChecks: true
+actions:
+  branch-protection-settings:
+    branches:
+      - name: main
+        dismissStaleReviews: true
+        requireBranchUpToDate: true
+        checks:
+          - name: Build & Test
+            type: tests
+  sync-code-owners:
+    extraWriters: ["plastic-issuance-service-owners"]


### PR DESCRIPTION
## Context

[Currently only a few people have write access to this repo](https://wise.slack.com/archives/C01012MB4VD/p1681892595859849), this is insufficient as it makes it impossible for anyone else to create a pull request. After talking to [#github-change-management](https://wise.slack.com/archives/C017DTDEBJR/p1681895934317039), they have suggested that we add a `tw-rules.yaml` file in the repo to control access to the repo.

The content of `tw-rules.yaml` is based on the template in [tw-service-template](https://github.com/transferwise/tw-service-template/blob/main/.github/tw-rules.yaml)

- It gives [Plastic Issuance Service Owners](https://github.com/orgs/transferwise/teams/plastic-issuance-service-owners) access to this repo, other than the ones who already have access today
- It adds some checks and rules for when merging to `master` is allowed

## Checklist

- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
