### PR TITLE
Change runner to gha-production-medium for build job

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -12,7 +12,7 @@ jobs:
 
   build-and-test:
     name: "Build & Test"
-    runs-on: ubuntu-latest
+    runs-on: gha-production-medium
 
     steps:
       - name: "Checkout git repo"


### PR DESCRIPTION
## Context

https://transferwise.atlassian.net/browse/PAT-5272

Migrates GitHub Actions workflows from cloud-hosted runners (ubuntu-latest, ubuntu-24.04, ubuntu-22.04, ubuntu-20.04) to self-hosted runners (gha-production-medium).

Why this change?
This migration is to align all workflows for egress controls via Cilium network policies for our GitHub Actions cluster, improving security by controlling outbound network traffic from CI jobs.

📖 More info: [Cilium network policies for GitHub Actions](https://transferwise.atlassian.net/wiki/spaces/CI/pages/3642301817/Cilium+network+policies+for+GitHub+Actions)

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
