### PR TITLE
SEC-1151 enforce KEK bundle completeness

### DIFF
--- a/kek/kek_bundle.go
+++ b/kek/kek_bundle.go
@@ -103,6 +103,10 @@ func (b *Bundle) Merge() (des.Cipher, error) {
 
 // MergeTripleDESKey tries to build the result TripleDES key from all the imported components
 func (b *Bundle) MergeTripleDESKey() (des.Cipher, error) {
+	if !b.IsComplete() {
+		return des.Cipher{}, fmt.Errorf("incomplete KEK bundle: expected %d components but got %d", b.Size, len(b.Components))
+	}
+
 	kekBytes := make([]byte, 24)
 	for _, component := range b.Components {
 		kekBytes, _ = xor.XORBytes(kekBytes, component)
@@ -121,6 +125,10 @@ func (b *Bundle) MergeTripleDESKey() (des.Cipher, error) {
 
 // MergeAESKey tries to build the result AES key from all the imported components
 func (b *Bundle) MergeAESKey() (aes.Cipher, error) {
+	if !b.IsComplete() {
+		return aes.Cipher{}, fmt.Errorf("incomplete KEK bundle: expected %d components but got %d", b.Size, len(b.Components))
+	}
+
 	var keyLen int
 	for _, component := range b.Components {
 		if keyLen == 0 {

--- a/kek/kek_bundle_test.go
+++ b/kek/kek_bundle_test.go
@@ -118,6 +118,23 @@ func TestMergeResultKeySuccess(t *testing.T) {
 	}
 }
 
+func TestMergeTripleDESKeyRejectsIncompleteBundleWithMatchingCheckValue(t *testing.T) {
+	kek := New("visa", 1, 3, "DD1375")
+
+	err := kek.AddComponent(1, "E38FD6D9EF85A892F2FBFDD083A407AE", "DD1375")
+	if err != nil {
+		t.Fatalf("adding component failed with %v", err)
+	}
+
+	_, err = kek.MergeTripleDESKey()
+	if err == nil {
+		t.Fatal("should have failed if the bundle is incomplete")
+	}
+	if err.Error() != "incomplete KEK bundle: expected 3 components but got 1" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 // AES KEK tests
 
 func TestAESAddComponentInvalidValue(t *testing.T) {
@@ -171,6 +188,23 @@ func TestAESMergeAESKeySuccess(t *testing.T) {
 	}
 	if resultKey.CheckValue() != "b1dd24" {
 		t.Fatalf("Expected check value b1dd24 but got %s", resultKey.CheckValue())
+	}
+}
+
+func TestMergeAESKeyRejectsIncompleteBundleWithMatchingCheckValue(t *testing.T) {
+	kek := NewWithKeyType("aes-kek", 1, 3, "B1DD24", KeyTypeAES)
+
+	err := kek.AddComponent(1, "574953452d504f430000000000546263", "B1DD24")
+	if err != nil {
+		t.Fatalf("adding component failed with %v", err)
+	}
+
+	_, err = kek.MergeAESKey()
+	if err == nil {
+		t.Fatal("should have failed if the bundle is incomplete")
+	}
+	if err.Error() != "incomplete KEK bundle: expected 3 components but got 1" {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Context

[SEC-1151](https://transferwise.atlassian.net/browse/SEC-1151)

Reject AES and TripleDES KEK merges until every declared component has been imported. This prevents a matching short KCV from making an incomplete bundle usable. Adds deterministic regression coverage for both key types.

Verified with `go test ./...` using Go 1.25.7 and a temporary module-file override for the unavailable Go 1.26 toolchain.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 

[SEC-1151]: https://transferwise.atlassian.net/browse/SEC-1151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ